### PR TITLE
Implement record listing and detail pages

### DIFF
--- a/frontend/components/ExhibitionForm.tsx
+++ b/frontend/components/ExhibitionForm.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useRouter } from 'next/router';
 import {
   Box,
   Button,
@@ -15,6 +16,7 @@ export default function ExhibitionForm() {
   const [date, setDate] = useState('');
   const [overall, setOverall] = useState('');
   const [works, setWorks] = useState<Work[]>([]);
+  const router = useRouter();
 
   const handleWorkChange = (index: number, field: keyof Work, value: any) => {
     setWorks((prev) =>
@@ -28,8 +30,20 @@ export default function ExhibitionForm() {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    // Placeholder for submit logic (e.g., Supabase)
-    console.log({ name, date, overall, works });
+    const newRecord = {
+      id: Date.now(),
+      name,
+      date,
+      overall,
+      works,
+    };
+    const existing = JSON.parse(
+      typeof window !== 'undefined'
+        ? localStorage.getItem('exhibitions') || '[]'
+        : '[]'
+    );
+    localStorage.setItem('exhibitions', JSON.stringify([...existing, newRecord]));
+    router.push('/');
   };
 
   return (

--- a/frontend/pages/exhibitions/[id].tsx
+++ b/frontend/pages/exhibitions/[id].tsx
@@ -1,0 +1,55 @@
+import { Box, Heading, List, ListItem, Text } from '@chakra-ui/react';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+interface Work {
+  title: string;
+  author: string;
+  comment: string;
+}
+
+interface Exhibition {
+  id: number;
+  name: string;
+  date: string;
+  overall: string;
+  works: Work[];
+}
+
+export default function ExhibitionDetail() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [exhibition, setExhibition] = useState<Exhibition | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    const data = JSON.parse(
+      typeof window !== 'undefined'
+        ? localStorage.getItem('exhibitions') || '[]'
+        : '[]'
+    ) as Exhibition[];
+    const found = data.find((ex) => ex.id === Number(id)) || null;
+    setExhibition(found);
+  }, [id]);
+
+  if (!exhibition) return <Text>Loading...</Text>;
+
+  return (
+    <Box p={8}>
+      <Heading as="h2" size="md" mb={4}>{exhibition.name}</Heading>
+      <Text>Date: {exhibition.date}</Text>
+      <Text mt={2}>{exhibition.overall}</Text>
+      <Heading as="h3" size="sm" mt={4} mb={2}>Works</Heading>
+      <List spacing={3}>
+        {exhibition.works.map((work, i) => (
+          <ListItem key={i}>
+            <strong>{work.title}</strong> by {work.author}
+            <Text>{work.comment}</Text>
+          </ListItem>
+        ))}
+      </List>
+      <Link href="/">Back to Home</Link>
+    </Box>
+  );
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,7 +1,26 @@
-import { Box, Button, Heading, VStack } from '@chakra-ui/react';
+import { Button, Heading, List, ListItem, VStack } from '@chakra-ui/react';
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+interface Exhibition {
+  id: number;
+  name: string;
+  date: string;
+}
 
 export default function Home() {
+  const [exhibitions, setExhibitions] = useState<Exhibition[]>([]);
+
+  useEffect(() => {
+    const data = JSON.parse(
+      typeof window !== 'undefined'
+        ? localStorage.getItem('exhibitions') || '[]'
+        : '[]'
+    );
+    const sorted = data.sort((a: Exhibition, b: Exhibition) => b.id - a.id);
+    setExhibitions(sorted);
+  }, []);
+
   return (
     <VStack spacing={4} p={8} align="stretch">
       <Heading as="h1" size="lg">My Art Album</Heading>
@@ -10,6 +29,13 @@ export default function Home() {
           New Exhibition Record
         </Button>
       </Link>
+      <List spacing={3} mt={4}>
+        {exhibitions.map((ex) => (
+          <ListItem key={ex.id}>
+            <Link href={`/exhibitions/${ex.id}`}>{`${ex.date} - ${ex.name}`}</Link>
+          </ListItem>
+        ))}
+      </List>
     </VStack>
   );
 }


### PR DESCRIPTION
## Summary
- add exhibition save handler and router redirect
- show saved exhibitions on home page sorted by newest first
- create exhibition detail page

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685a17c1c3b48330a6a3ea557582ab43