### PR TITLE
Implement celeste-themed layout with bottom bar

### DIFF
--- a/frontend/components/BottomBar.tsx
+++ b/frontend/components/BottomBar.tsx
@@ -1,0 +1,25 @@
+import { Flex, Button } from '@chakra-ui/react';
+import Link from 'next/link';
+
+export default function BottomBar() {
+  return (
+    <Flex
+      position="fixed"
+      bottom={0}
+      left={0}
+      width="100%"
+      bg="white"
+      borderTop="1px solid #e2e8f0"
+      py={2}
+      justify="space-around"
+      zIndex={1000}
+    >
+      <Link href="/" passHref>
+        <Button colorScheme="brand" variant="ghost">Home</Button>
+      </Link>
+      <Link href="/new-exhibition" passHref>
+        <Button colorScheme="brand" variant="ghost">New</Button>
+      </Link>
+    </Flex>
+  );
+}

--- a/frontend/components/ExhibitionForm.tsx
+++ b/frontend/components/ExhibitionForm.tsx
@@ -71,8 +71,10 @@ export default function ExhibitionForm() {
             onRemove={removeWork}
           />
         ))}
-        <Button onClick={addWork}>Add Work</Button>
-        <Button type="submit" colorScheme="teal">
+        <Button onClick={addWork} colorScheme="brand" variant="outline">
+          Add Work
+        </Button>
+        <Button type="submit" colorScheme="brand">
           Save Record
         </Button>
       </VStack>

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,0 +1,13 @@
+import type { AppProps } from 'next/app';
+import { ChakraProvider } from '@chakra-ui/react';
+import theme from '../theme';
+import BottomBar from '../components/BottomBar';
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <ChakraProvider theme={theme}>
+      <Component {...pageProps} />
+      <BottomBar />
+    </ChakraProvider>
+  );
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -25,7 +25,7 @@ export default function Home() {
     <VStack spacing={4} p={8} align="stretch">
       <Heading as="h1" size="lg">My Art Album</Heading>
       <Link href="/new-exhibition" passHref>
-        <Button colorScheme="teal" width="fit-content">
+        <Button colorScheme="brand" width="fit-content">
           New Exhibition Record
         </Button>
       </Link>

--- a/frontend/theme.ts
+++ b/frontend/theme.ts
@@ -1,0 +1,33 @@
+import { extendTheme, ThemeConfig } from '@chakra-ui/react';
+
+const config: ThemeConfig = {
+  initialColorMode: 'light',
+  useSystemColorMode: false,
+};
+
+const theme = extendTheme({
+  config,
+  colors: {
+    brand: {
+      50: '#e6ffff',
+      100: '#b2ffff',
+      200: '#9ae9e9',
+      300: '#7ad7d7',
+      400: '#5dc4c4',
+      500: '#40b1b1',
+      600: '#319292',
+      700: '#237373',
+      800: '#154444',
+      900: '#072626',
+    },
+  },
+  styles: {
+    global: {
+      body: {
+        bg: 'white',
+      },
+    },
+  },
+});
+
+export default theme;


### PR DESCRIPTION
## Summary
- apply a new Chakra UI theme using a bright celeste color
- add global `_app` wrapper and a fixed bottom button bar
- update buttons to use the new `brand` color

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685a1b4ea74883308a75353e3fab2af6