### PR TITLE
Improve detail page layout

### DIFF
--- a/frontend/components/ExhibitionForm.tsx
+++ b/frontend/components/ExhibitionForm.tsx
@@ -24,7 +24,8 @@ export default function ExhibitionForm() {
     );
   };
 
-  const addWork = () => setWorks([...works, { title: '', author: '', image: null, comment: '' }]);
+  const addWork = () =>
+    setWorks([...works, { title: '', author: '', image: null, comment: '' }]);
 
   const removeWork = (index: number) => setWorks(works.filter((_, i) => i !== index));
 

--- a/frontend/components/WorkInput.tsx
+++ b/frontend/components/WorkInput.tsx
@@ -4,7 +4,7 @@ import { Box, Button, FormControl, FormLabel, Input, Textarea } from '@chakra-ui
 export interface Work {
   title: string;
   author: string;
-  image?: File | null;
+  image?: string | null;
   comment: string;
 }
 
@@ -17,8 +17,16 @@ interface Props {
 
 export default function WorkInput({ index, work, onChange, onRemove }: Props) {
   const handleFile = (e: ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0] || null;
-    onChange(index, 'image', file);
+    const file = e.target.files?.[0];
+    if (!file) {
+      onChange(index, 'image', null);
+      return;
+    }
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      onChange(index, 'image', reader.result as string);
+    };
+    reader.readAsDataURL(file);
   };
 
   return (

--- a/frontend/pages/exhibitions/[id].tsx
+++ b/frontend/pages/exhibitions/[id].tsx
@@ -1,4 +1,4 @@
-import { Box, Heading, List, ListItem, Text } from '@chakra-ui/react';
+import { Box, Heading, Image, Text, VStack } from '@chakra-ui/react';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
@@ -6,6 +6,7 @@ import Link from 'next/link';
 interface Work {
   title: string;
   author: string;
+  image?: string | null;
   comment: string;
 }
 
@@ -41,14 +42,24 @@ export default function ExhibitionDetail() {
       <Text>Date: {exhibition.date}</Text>
       <Text mt={2}>{exhibition.overall}</Text>
       <Heading as="h3" size="sm" mt={4} mb={2}>Works</Heading>
-      <List spacing={3}>
+      <VStack spacing={6} align="stretch">
         {exhibition.works.map((work, i) => (
-          <ListItem key={i}>
-            <strong>{work.title}</strong> by {work.author}
-            <Text>{work.comment}</Text>
-          </ListItem>
+          <Box key={i} borderWidth="1px" borderRadius="md" overflow="hidden">
+            {work.image && (
+              <Image src={work.image} alt={work.title} width="100%" />
+            )}
+            <Box p={4}>
+              <Heading as="h4" size="sm">
+                {work.title}
+              </Heading>
+              <Text fontSize="sm" color="gray.600">
+                {work.author}
+              </Text>
+              <Text mt={2}>{work.comment}</Text>
+            </Box>
+          </Box>
         ))}
-      </List>
+      </VStack>
       <Link href="/">Back to Home</Link>
     </Box>
   );


### PR DESCRIPTION
## Summary
- convert uploaded work images to base64 strings
- show images and stylize work items on the exhibition detail page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685a1e5978308330a4b2a5c19ec73dc8